### PR TITLE
Atualizar parâmetros de autenticação do Zendesk para serem opcionais e adicionar suporte a token de acesso

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,13 @@ inputs:
     required: true
   zendesk_email:
     description: "Zendesk email to authenticate"
-    required: true
+    required: false
   zendesk_api_token:
     description: "Zendesk api token to authenticate"
-    required: true
+    required: false
+  zendesk_access_token:
+    description: "Zendesk access token to authenticate"
+    required: false
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -23041,18 +23041,21 @@ const number_1 = __nccwpck_require__(6755);
 const { ref, eventName, payload: { repository }, } = github.context;
 function getAuthenticateParams() {
     const subdomain = (0, core_1.getInput)('zendesk_subdomain', { required: true });
-    const email = (0, core_1.getInput)('zendesk_email', { required: true });
-    const apiToken = (0, core_1.getInput)('zendesk_api_token', { required: true });
+    const email = (0, core_1.getInput)('zendesk_email', { required: false });
+    const apiToken = (0, core_1.getInput)('zendesk_api_token', { required: false });
+    const accessToken = (0, core_1.getInput)('zendesk_access_token', { required: false });
+    if (!subdomain) {
+        throw new Error('Authentication parameters validation: "zendesk_subdomain" is required.');
+    }
+    if (!((email && apiToken) || accessToken)) {
+        throw new Error('Authentication parameters validation: You must provide either "zendesk_email" and "zendesk_api_token" or "zendesk_access_token".');
+    }
     const auth = {
         subdomain,
         email,
         apiToken,
+        accessToken,
     };
-    const missingAuthParams = Object.keys(auth).filter((param) => typeof auth[param] !== 'string');
-    if (missingAuthParams.length)
-        throw new Error(`Following authentication variables missing their values: ${missingAuthParams
-            .map((param) => param)
-            .join(', ')}`);
     return auth;
 }
 function getAppInput() {
@@ -23164,14 +23167,18 @@ const form_data_1 = __importDefault(__nccwpck_require__(4334));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const axios_1 = __importDefault(__nccwpck_require__(8757));
 class ZendeskAPI {
-    constructor({ apiToken, email, subdomain }) {
+    constructor({ apiToken, email, subdomain, accessToken, }) {
         this.api = axios_1.default.create({
             baseURL: `https://${subdomain}.zendesk.com/api/v2`,
-            auth: {
-                username: `${email}/token`,
-                password: apiToken,
-            },
         });
+        if (apiToken && email) {
+            const authString = Buffer.from(`${email}/token:${apiToken}`).toString('base64');
+            this.api.defaults.headers.common['Authorization'] = `Basic ${authString}`;
+        }
+        else {
+            this.api.defaults.headers.common['Authorization'] =
+                `Bearer ${accessToken}`;
+        }
     }
     uploadApp(appFilePath) {
         return __awaiter(this, void 0, void 0, function* () {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
     "jest": "^29.1.2",
     "prettier": "^3.2.4",
     "typescript": "^4.8.4"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,25 +17,28 @@ const {
 
 function getAuthenticateParams(): AuthenticateZendesk {
   const subdomain = getInput('zendesk_subdomain', { required: true });
-  const email = getInput('zendesk_email', { required: true });
-  const apiToken = getInput('zendesk_api_token', { required: true });
+  const email = getInput('zendesk_email', { required: false });
+  const apiToken = getInput('zendesk_api_token', { required: false });
+  const accessToken = getInput('zendesk_access_token', { required: false });
+
+  if (!subdomain) {
+    throw new Error(
+      'Authentication parameters validation: "zendesk_subdomain" is required.',
+    );
+  }
+
+  if (!((email && apiToken) || accessToken)) {
+    throw new Error(
+      'Authentication parameters validation: You must provide either "zendesk_email" and "zendesk_api_token" or "zendesk_access_token".',
+    );
+  }
 
   const auth: AuthenticateZendesk = {
     subdomain,
     email,
     apiToken,
+    accessToken,
   };
-
-  const missingAuthParams = Object.keys(auth).filter(
-    (param) => typeof auth[param as keyof AuthenticateZendesk] !== 'string',
-  );
-
-  if (missingAuthParams.length)
-    throw new Error(
-      `Following authentication variables missing their values: ${missingAuthParams
-        .map((param) => param)
-        .join(', ')}`,
-    );
 
   return auth;
 }

--- a/src/providers/ZendeskAPI.ts
+++ b/src/providers/ZendeskAPI.ts
@@ -5,14 +5,25 @@ import axios, { AxiosInstance } from 'axios';
 export default class ZendeskAPI {
   private api: AxiosInstance;
 
-  constructor({ apiToken, email, subdomain }: AuthenticateZendesk) {
+  constructor({
+    apiToken,
+    email,
+    subdomain,
+    accessToken,
+  }: AuthenticateZendesk) {
     this.api = axios.create({
       baseURL: `https://${subdomain}.zendesk.com/api/v2`,
-      auth: {
-        username: `${email}/token`,
-        password: apiToken,
-      },
     });
+
+    if (apiToken && email) {
+      const authString = Buffer.from(`${email}/token:${apiToken}`).toString(
+        'base64',
+      );
+      this.api.defaults.headers.common['Authorization'] = `Basic ${authString}`;
+    } else {
+      this.api.defaults.headers.common['Authorization'] =
+        `Bearer ${accessToken}`;
+    }
   }
 
   async uploadApp(appFilePath: string) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,9 +5,10 @@ type ManifestParamProps = {
 };
 
 type AuthenticateZendesk = {
-  email: string;
+  email?: string;
   subdomain: string;
-  apiToken: string;
+  apiToken?: string;
+  accessToken?: string;
 };
 
 type ZendeskAppsConfig = {


### PR DESCRIPTION
Os parâmetros de autenticação do Zendesk agora são opcionais, permitindo o uso de um token de acesso como alternativa.

Para testar utilize o ezsend-one com a branch [test/pipeline-accessToken](https://github.com/eteg/ezsend-one/tree/test/pipeline-accessToken), para testar rode a pipeline de **Frontend CD** como na imagem abaixo

<img width="1650" height="764" alt="image" src="https://github.com/user-attachments/assets/5dea218a-ad98-4b27-b73d-154ffbdc861b" />



Isso ira criar um APP no D3V com o nome de **eZSend One - Teste AccessToken** utilizando o AccessToken

Ai depois por garantia modifica a linha 272-274 no arquivo frontend.cd.yaml para testar utilizando o basic auth